### PR TITLE
Fix broken links to merge requests by including path with namespace.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabRepository.java
@@ -109,7 +109,7 @@ public class GitlabRepository {
 
     public String getProjectUrl() {
         try {
-            return _builder.getGitlab().get().getUrl(_project.getPath()).toString();
+            return _builder.getGitlab().get().getUrl(_project.getPathWithNamespace()).toString();
         } catch (IOException e) {
             return null;
         }


### PR DESCRIPTION
Closes issue #9.
