### PR TITLE
Check if author is null before check futher details.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
@@ -83,7 +83,8 @@ public class GitlabMergeRequestWrapper {
             });
 
             for (GitlabNote note : notes) {
-                if (note.getAuthor().getUsername().equals(GitlabBuildTrigger.getDesc().getBotUsername())) {
+                if (note.getAuthor() != null &&
+                        note.getAuthor().getUsername().equals(GitlabBuildTrigger.getDesc().getBotUsername())) {
                     lastJenkinsNote = note;
                     break;
                 }


### PR DESCRIPTION
We have some notes on merge requests where the author is null. We using Gitlab since v3 so it could be some inconsistency when we had deleted a user.
