### PR TITLE
Update MR links to use the project internal IDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
           <groupId>org.gitlab</groupId>
           <artifactId>java-gitlab-api</artifactId>
-          <version>1.1.2</version>
+          <version>1.1.3-SNAPSHOT</version>
       </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
@@ -59,6 +59,7 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         Map<String, ParameterValue> values = getDefaultParameters();
 
         values.put("gitlabMergeRequestId", new StringParameterValue("gitlabMergeRequestId", String.valueOf(cause.getMergeRequestId())));
+        values.put("gitlabMergeRequestIid", new StringParameterValue("gitlabMergeRequestIid", String.valueOf(cause.getMergeRequestIid())));
         values.put("gitlabSourceBranch", new StringParameterValue("gitlabSourceBranch", cause.getSourceBranch()));
         values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", cause.getTargetBranch()));
 

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
@@ -20,7 +20,7 @@ public class GitlabBuilds {
     }
 
     public String build(GitlabMergeRequestWrapper mergeRequest) {
-        GitlabCause cause = new GitlabCause(mergeRequest.getId(), mergeRequest.getSource(), mergeRequest.getTarget());
+        GitlabCause cause = new GitlabCause(mergeRequest.getId(), mergeRequest.getIid(), mergeRequest.getSource(), mergeRequest.getTarget());
 
         QueueTaskFuture<?> build = _trigger.startJob(cause);
         if (build == null) {
@@ -49,7 +49,7 @@ public class GitlabBuilds {
         }
 
         try {
-            build.setDescription("<a href=\"" + _repository.getMergeRequestUrl(cause.getMergeRequestId()) + "\">" + getOnStartedMessage(cause) + "</a>");
+            build.setDescription("<a href=\"" + _repository.getMergeRequestUrl(cause.getMergeRequestIid()) + "\">" + getOnStartedMessage(cause) + "</a>");
         } catch (IOException e) {
             _logger.log(Level.SEVERE, "Can't update build description", e);
         }
@@ -72,10 +72,9 @@ public class GitlabBuilds {
         String buildUrl = Jenkins.getInstance().getRootUrl() + build.getUrl();
         stringBuilder.append("\nBuild results available at: ").append(buildUrl);
         _repository.createNote(cause.getMergeRequestId(), stringBuilder.toString());
-
     }
 
     private String getOnStartedMessage(GitlabCause cause) {
-        return "Merge Request #" + cause.getMergeRequestId() + " (" + cause.getSourceBranch() + " => " + cause.getTargetBranch() + ")";
+        return "Merge Request #" + cause.getMergeRequestIid() + " (" + cause.getSourceBranch() + " => " + cause.getTargetBranch() + ")";
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabCause.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabCause.java
@@ -4,11 +4,13 @@ import hudson.model.Cause;
 
 public class GitlabCause extends Cause {
     private final Integer _mergeRequestId;
+    private final Integer _mergeRequestIid;
     private final String _sourceBranch;
     private final String _targetBranch;
 
-    public GitlabCause(Integer mergeRequestId, String sourceBranch, String targetBranch) {
+    public GitlabCause(Integer mergeRequestId, Integer mergeRequestIid, String sourceBranch, String targetBranch) {
         _mergeRequestId = mergeRequestId;
+        _mergeRequestIid = mergeRequestIid;
         _sourceBranch = sourceBranch;
         _targetBranch = targetBranch;
     }
@@ -16,11 +18,15 @@ public class GitlabCause extends Cause {
 
     @Override
     public String getShortDescription() {
-        return "Gitlab Merge Request #" + _mergeRequestId + " : " + _sourceBranch + " => " + _targetBranch;
+        return "Gitlab Merge Request #" + _mergeRequestIid + " : " + _sourceBranch + " => " + _targetBranch;
     }
 
     public Integer getMergeRequestId() {
         return _mergeRequestId;
+    }
+
+    public Integer getMergeRequestIid() {
+        return _mergeRequestIid;
     }
 
     public String getSourceBranch() {

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
@@ -16,6 +16,7 @@ public class GitlabMergeRequestWrapper {
 
     private static final Logger _logger = Logger.getLogger(GitlabMergeRequestWrapper.class.getName());
     private final Integer _id;
+    private Integer _iid;
     private final String _author;
     private String _source;
     private String _target;
@@ -28,6 +29,7 @@ public class GitlabMergeRequestWrapper {
 
     GitlabMergeRequestWrapper(GitlabMergeRequest mergeRequest, GitlabMergeRequestBuilder builder, GitlabProject project) {
         _id = mergeRequest.getId();
+        _iid = mergeRequest.getIid();
         _author = mergeRequest.getAuthor().getUsername();
         _source = mergeRequest.getSourceBranch();
         _target = mergeRequest.getTargetBranch();
@@ -41,6 +43,10 @@ public class GitlabMergeRequestWrapper {
     }
 
     public void check(GitlabMergeRequest gitlabMergeRequest) {
+        if (_iid == null) {
+            _iid = gitlabMergeRequest.getIid();
+        }
+
         if (_target == null) {
             _target = gitlabMergeRequest.getTargetBranch();
         }
@@ -113,6 +119,10 @@ public class GitlabMergeRequestWrapper {
         return _id;
     }
 
+    public Integer getIid() {
+        return _iid;
+    }
+
     public String getAuthor() {
         return _author;
     }
@@ -128,6 +138,7 @@ public class GitlabMergeRequestWrapper {
     public GitlabNote createNote(String message) {
         GitlabMergeRequest mergeRequest = new GitlabMergeRequest();
         mergeRequest.setId(_id);
+        mergeRequest.setIid(_iid);
         mergeRequest.setProjectId(_project.getId());
 
         try {

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabRepository.java
@@ -115,8 +115,8 @@ public class GitlabRepository {
         }
     }
 
-    public String getMergeRequestUrl(Integer mergeRequestId) {
-        return getProjectUrl() + GitlabMergeRequest.URL + "/" + mergeRequestId;
+    public String getMergeRequestUrl(Integer mergeRequestIid) {
+        return getProjectUrl() + GitlabMergeRequest.URL + "/" + mergeRequestIid;
     }
 
     public GitlabNote createNote(Integer mergeRequestId, String message) {


### PR DESCRIPTION
Links to MRs are broken for the latest GitLab versions that are using internal IDs.  This fixes #31 

Requires this pull request timols/java-gitlab-api/pull/4
