### PR TITLE
http access is sufficient for cloning

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
@@ -164,7 +164,7 @@ public class GitlabMergeRequestWrapper {
     }
 
     public String getSourceRepository() {
-        return _sourceProject.getSshUrl();
+        return _sourceProject.getHttpUrl();
     }
 
     public String getSourceBranch() {


### PR DESCRIPTION
it requires a recent version of java gitlab client
