### PR TITLE
Make the Jenkins build URL in MR comments clickable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
@@ -74,7 +74,8 @@ public class GitlabBuilds {
         }
 
         String buildUrl = Jenkins.getInstance().getRootUrl() + build.getUrl();
-        stringBuilder.append("\nBuild results available at: ").append(buildUrl);
+        stringBuilder.append("\nBuild results available at: ")
+            .append("[").append(buildUrl).append("](").append(buildUrl).append(")"); // Link in markdown format
         _repository.createNote(cause.getMergeRequestId(), stringBuilder.toString());
     }
 


### PR DESCRIPTION
Gitlab supports Markdown in comments, so write the URL in `[link text](url)` format.

Example MR comment:

```
Build finished. Tests PASSED. Build results available at: [http://jenkins/job/my-job/123/](http://jenkins/job/my-job/123/)
```
