### PR TITLE
Updated Jenkins version dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.563</version><!-- which version of Jenkins is this plugin built against? -->
+        <version>1.554</version><!-- which version of Jenkins is this plugin built against? -->
     </parent>
 
     <groupId>com.switchfly</groupId>


### PR DESCRIPTION
Set the dependency on Jenkins to the latest LTS version. I wasn't aware of the LTS versions when I submitted my previous pull request.
