### PR TITLE
Add regex that allows a job to only be executed for specific branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 tmp/*
+*.orig
 target/*
 .idea/*
 work/*

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ request indicating whether the merge request was successful.
 * In the ``Build Triggers`` section:
     * Check the ``Gitlab Merge Requests Builder``
     * Enter the ``Gitlab Project Path``, this might be something like ``your_group/your_project`` for gitlab url ``http://git.tld/your_group/your_project``
+    * The ``Target Branch Regex`` may be configured to whitelist this job for certain target branches. If left empty, every valid merge request for the configured project path will trigger this job.
 * Configure any other pre build, build or post build actions as necessary
 * ``Save`` to preserve your changes
 

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
@@ -29,13 +29,15 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     private final String _cron;
     private final String _projectPath;
+    private final String _targetBranchRegex;
     transient private GitlabMergeRequestBuilder _gitlabMergeRequestBuilder;
 
     @DataBoundConstructor
-    public GitlabBuildTrigger(String cron, String projectPath) throws ANTLRException {
+    public GitlabBuildTrigger(String cron, String projectPath, String targetBranchRegex) throws ANTLRException {
         super(cron);
         _cron = cron;
         _projectPath = projectPath;
+        _targetBranchRegex = targetBranchRegex;
     }
 
     @Override
@@ -122,6 +124,10 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public String getProjectPath() {
         return _projectPath;
+    }
+
+    public String getTargetBranchRegex() {
+        return _targetBranchRegex;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestBuilder.java
@@ -32,6 +32,10 @@ public class GitlabMergeRequestBuilder {
         return this;
     }
 
+    public GitlabBuildTrigger getTrigger() {
+        return _trigger;
+    }
+
     public GitlabMergeRequestBuilder setProject(AbstractProject<?, ?> project) {
         _project = project;
 

--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
@@ -3,6 +3,10 @@
             description="The full path including namespace to the project">
         <f:textbox />
     </f:entry>
+    <f:entry title="Target Branch Regex" field="targetBranchRegex"
+            description="The full path including namespace to the project">
+        <f:textbox />
+    </f:entry>
     <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
         <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/help-targetBranchRegex.html
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/help-targetBranchRegex.html
@@ -1,0 +1,10 @@
+<div>
+  <p>The target branch regex is used to allow execution of this job for certain branches. The regex will be not used when this field is left empty.</p>
+  <p>Examples:</p>
+  <pre>
+#  Allow execution for release and hotfix branches
+(.*release.*|.*hotfix.*)
+# Allow execution for dev branches only
+.*dev.*
+  </pre>
+</div>


### PR DESCRIPTION
I customized the GitlabBuildTrigger and added a new field in which the user can specify a regex.
This regex is used in the GitlabMergeRequestWrapper to decide whether the job should be executed or not.
The target branch name will not be checked using the regex when no regex has been defined in the trigger field.
