### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ request indicating whether the merge request was successful.
     * Search for ``Gitlab Merge Request Builder``
     * And install it
     * Ensure you restart Jenkins
-* Go to ``Manage Jenkins`` -> ``Configure System`` -> ``Gitlab Merge Requests Builder``
+* Go to ``Manage Jenkins`` -> ``Configure System`` -> ``Gitlab Merge Request Builder``
 * Set the ``Gitlab Host URL`` to the base URL of your Gitlab server
 * Set your ``Jenkins Username`` for the Jenkins user (defaults to jenkins)
 * Set your ``Jenkins API Token`` for the Jenkins user. This can be found by logging into Gitlab as Jenkins


### PR DESCRIPTION
The config header is "Gitlab Merge Request Builder", not "Gitlab Merge Requests Builder" (i.e. Request, not Requests), makes it easier to follow instructions directly and Ctrl+F on the page. If "Requests" would be better I believe this is the corresponding bit on the config page itself: https://github.com/timols/jenkins-gitlab-merge-request-builder-plugin/blob/1.2.2/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/global.jelly#L2
