### PR TITLE
Allow use of HTTP URL for source repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ request indicating whether the merge request was successful.
     * Check the ``Gitlab Merge Requests Builder``
     * Enter the ``Gitlab Project Path``, this might be something like ``your_group/your_project`` for gitlab url ``http://git.tld/your_group/your_project``
     * The ``Target Branch Regex`` may be configured to whitelist this job for certain target branches. If left empty, every valid merge request for the configured project path will trigger this job.
+    * The ``Use HTTP(S) URL`` checkbox should be used if you want Jenkins to
+clone/fetch using HTTP(S) instead of SSH.
 * Configure any other pre build, build or post build actions as necessary
 * ``Save`` to preserve your changes
 

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
@@ -30,14 +30,16 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String _cron;
     private final String _projectPath;
     private final String _targetBranchRegex;
+    private final Boolean _useHttpUrl;
     transient private GitlabMergeRequestBuilder _gitlabMergeRequestBuilder;
 
     @DataBoundConstructor
-    public GitlabBuildTrigger(String cron, String projectPath, String targetBranchRegex) throws ANTLRException {
+    public GitlabBuildTrigger(String cron, String projectPath, String targetBranchRegex, Boolean useHttpUrl ) throws ANTLRException {
         super(cron);
         _cron = cron;
         _projectPath = projectPath;
         _targetBranchRegex = targetBranchRegex;
+        _useHttpUrl = useHttpUrl;
     }
 
     @Override
@@ -128,6 +130,10 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public String getTargetBranchRegex() {
         return _targetBranchRegex;
+    }
+
+    public Boolean getUseHttpUrl() {
+        return _useHttpUrl;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
@@ -220,7 +220,11 @@ public class GitlabMergeRequestWrapper {
     }
 
     public String getSourceRepository() {
-        return _sourceProject.getHttpUrl();
+        if (_builder.getTrigger().getUseHttpUrl()) {
+            return _sourceProject.getHttpUrl();
+        } else {
+            return _sourceProject.getSshUrl();
+        }
     }
 
     public String getSourceBranch() {

--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
@@ -10,4 +10,8 @@
     <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
         <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
     </f:entry>
+    <f:entry title="Use HTTP(s) URL" field="useHttpUrl"
+            description="Use the HTTP(S) URL to fetch/clone repository">
+        <f:checkbox />
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
Solved #55 by adding a configuration flag (default to unset)
