### PR TITLE
Encrypt API token and make field password for security

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/Gitlab.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/Gitlab.java
@@ -9,7 +9,7 @@ public class Gitlab {
     private GitlabAPI _api;
 
     private void connect() {
-        String privateToken = GitlabBuildTrigger.getDesc().getBotApiToken();
+        String privateToken = GitlabBuildTrigger.getDesc().getBotApiTokenSecret().getPlainText();
         String apiUrl = GitlabBuildTrigger.getDesc().getGitlabHostUrl();
         _api = GitlabAPI.connect(apiUrl, privateToken);
     }

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
@@ -19,6 +19,7 @@ import hudson.model.queue.QueueTaskFuture;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -142,7 +143,8 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     public static final class GitlabBuildTriggerDescriptor extends TriggerDescriptor {
         private String _botUsername = "jenkins";
         private String _gitlabHostUrl;
-        private String _botApiToken;
+        @Deprecated private String _botApiToken;
+        private Secret _botApiTokenSecret;
         private String _cron = "*/5 * * * *";
         private boolean _enableBuildTriggeredMessage = true;
         private String _successMessage = "Build finished.  Tests PASSED.";
@@ -157,6 +159,10 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             load();
             if (_jobs == null) {
                 _jobs = new HashMap<String, Map<Integer, GitlabMergeRequestWrapper>>();
+            }
+            if (_botApiTokenSecret == null) {
+                _botApiTokenSecret = Secret.fromString(_botApiToken);
+                _botApiToken = null;
             }
         }
 
@@ -173,7 +179,7 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             _botUsername = formData.getString("botUsername");
-            _botApiToken = formData.getString("botApiToken");
+            _botApiTokenSecret = Secret.fromString(formData.getString("botApiTokenSecret"));
             _gitlabHostUrl = formData.getString("gitlabHostUrl");
             _cron = formData.getString("cron");
             _enableBuildTriggeredMessage = formData.getBoolean("enableBuildTriggeredMessage");
@@ -268,8 +274,16 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             return result;
         }
 
+        /**
+         * @deprecated use {@link #getBotApiTokenSecret()}.
+         */
+        @Deprecated
         public String getBotApiToken() {
-            return _botApiToken;
+            return _botApiTokenSecret.getPlainText();
+        }
+
+        public Secret getBotApiTokenSecret() {
+            return _botApiTokenSecret;
         }
 
         public String getGitlabHostUrl() {

--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/global.jelly
@@ -8,9 +8,9 @@
            description="Username for jenkins to use on Gitlab">
       <f:textbox/>
     </f:entry>
-    <f:entry title="Jenkins API Token" field="botApiToken"
+    <f:entry title="Jenkins API Token" field="botApiTokenSecret"
            description="API Token for the Jenkins user">
-      <f:textbox/>
+      <f:password/>
     </f:entry>
     <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
       <f:textbox default="H/5 * * * *" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>


### PR DESCRIPTION
The Gitlab API allows users to perform various actions with just a token, including certain write/modify events. Therefore any leak of a token could allow external users to perform actions under an ID other than theirs. This change makes the token input into a password field to hide the value and changes the java field into a `Secret` to ensure its value is encrypted on disk when next saved.
