### PR TITLE
fix: multiple merge request builds at first run depending on job duration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
@@ -95,7 +95,7 @@ public class GitlabMergeRequestWrapper {
 
             if (lastJenkinsNote == null) {
                 _logger.info("Latest note from Jenkins is null");
-                _shouldRun = true;
+                _shouldRun = latestCommitIsNotReached(latestCommit);
             } else if (latestCommit == null) {
                 _logger.log(Level.SEVERE, "Failed to determine the lastest commit for merge request {" + gitlabMergeRequest.getId() + "}. This might be caused by a stalled MR in gitlab.");
                 return;


### PR DESCRIPTION
The jobs were triggered multiple times when the check runs on a MR at second/thrid... time and the job duration takes more time than the next check on the MR set by cron.
