### PR TITLE
Added support for custom parameters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
@@ -6,6 +6,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
 import antlr.ANTLRException;
 import hudson.Extension;
 import hudson.model.AbstractProject;
@@ -21,9 +26,6 @@ import hudson.triggers.TriggerDescriptor;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
 
 public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private static final Logger _logger = Logger.getLogger(GitlabBuildTrigger.class.getName());
@@ -72,6 +74,9 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         values.put("gitlabSourceRepository", new StringParameterValue("gitlabSourceRepository", cause.getSourceRepository()));
         values.put("gitlabSourceBranch", new StringParameterValue("gitlabSourceBranch", cause.getSourceBranch()));
         values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", cause.getTargetBranch()));
+        for(Map.Entry<String, String> entry: cause.getCustomParameters().entrySet()) {
+        	values.put(entry.getKey(), new StringParameterValue(entry.getKey(), entry.getValue()));
+        }
 
         List<ParameterValue> listValues = new ArrayList<ParameterValue>(values.values());
         return this.job.scheduleBuild2(0, cause, new ParametersAction(listValues));

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabCause.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabCause.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.gitlab;
 
+import java.util.Map;
+
 import hudson.model.Cause;
 
 public class GitlabCause extends Cause {
@@ -9,15 +11,17 @@ public class GitlabCause extends Cause {
     private final String _sourceRepository;
     private final String _sourceBranch;
     private final String _targetBranch;
+	private final Map<String, String> _customParameters;
 
     public GitlabCause(Integer mergeRequestId, Integer mergeRequestIid, String sourceName,
-            String sourceRepository, String sourceBranch, String targetBranch) {
+            String sourceRepository, String sourceBranch, String targetBranch, Map<String, String> customParameters) {
         _mergeRequestId = mergeRequestId;
         _mergeRequestIid = mergeRequestIid;
         _sourceName = sourceName;
         _sourceRepository = sourceRepository;
         _sourceBranch = sourceBranch;
         _targetBranch = targetBranch;
+		_customParameters = customParameters;
     }
 
 
@@ -50,4 +54,8 @@ public class GitlabCause extends Cause {
     public String getTargetBranch() {
         return _targetBranch;
     }
+    
+    public Map<String, String> getCustomParameters() {
+		return _customParameters;
+	}
 }


### PR DESCRIPTION
We need an ability for some merge requests to instruct the jenkins job with some additional parameter in certain cases. This merge request allows that by instructing the bot-user to use a parameter (or remove a previously added parameter).

This can be done using a comment on the merge request in the format:
`@[bot-username]:use-parameter: MyParam=Some Value`

Or removing can happen in another comment:
`@[bot-username]:remove-parameter:MyParam`

If you want to set multiple parameters, you need multiple comments.