### PR TITLE
Post link to build even if automerge/close fails

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
@@ -330,11 +330,17 @@ public class GitlabMergeRequestWrapper {
                 }
                 _builder.getGitlab().get().retrieve().method("PUT").to(tailUrl, Void.class);
             }
+        } catch (IOException e) {
+            _logger.log(Level.SEVERE, "Failed to automatically merge/close the merge request " + _id, e);
+        }
+
+        try{
             return _builder.getGitlab().get().createNote(mergeRequest, message);
         } catch (IOException e) {
             _logger.log(Level.SEVERE, "Failed to create note for merge request " + _id, e);
             return null;
         }
+
     }
 
     private void build(Map<String, String> customParameters) {


### PR DESCRIPTION
Right now if, after the tests, Jenkins is not able to close or merge the merge request he doesn't leave any comment on the MR.

With this patch Jenkins leaves a comment anyway, even if he is not able to automatically close the merge request. In this way the user has a link to the build to investigate.