### PR TITLE
Using Build Cause as the Build Description

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
@@ -137,6 +137,6 @@ public class GitlabBuilds {
     }
 
     private String getOnStartedMessage(GitlabCause cause) {
-        return "Merge Request #" + cause.getMergeRequestIid() + " (" + cause.getSourceBranch() + " => " + cause.getTargetBranch() + ")";
+        return cause.getShortDescription();
     }
 }


### PR DESCRIPTION
This PR would close #140.

I don't have experience building jenkins plugins so I was not able to try out this code change. It seems simple enough that someone familiar with the code should be able to give :+1: or :-1: .