### PR TITLE
Change the commit status when builds run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ version = '1.2.3-SNAPSHOT'
 description = 'A plugin to build merge requests in Gitlab'
 
 jenkinsPlugin {
-	coreVersion = '1.554'
+	coreVersion = '1.633'
 	displayName = 'Gitlab Merge Request Builder'
 	url = 'https://wiki.jenkins-ci.org/display/JENKINS/Gitlab+Merge+Request+Builder+Plugin'
 	gitHubUrl = 'https://github.com/timols/jenkins-gitlab-merge-request-builder-plugin'

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.554</version><!-- which version of Jenkins is this plugin built against? -->
+        <version>1.633</version><!-- which version of Jenkins is this plugin built against? -->
     </parent>
 
     <groupId>com.switchfly</groupId>

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger.java
@@ -194,6 +194,7 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         private String unstableMessage = "Build finished.  Tests FAILED.";
         private String failureMessage = "Build finished.  Tests FAILED.";
         private boolean ignoreCertificateErrors = false;
+        private boolean updateCommitStatus = false;
 
         private transient Gitlab gitlab;
         private Map<String, Map<Integer, GitlabMergeRequestWrapper>> jobs;
@@ -231,6 +232,7 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             unstableMessage = formData.getString("unstableMessage");
             failureMessage = formData.getString("failureMessage");
             ignoreCertificateErrors = formData.getBoolean("ignoreCertificateErrors");
+            updateCommitStatus = formData.getBoolean("updateCommitStatus");
 
             save();
 
@@ -307,6 +309,10 @@ public final class GitlabBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
         public boolean isIgnoreCertificateErrors() {
             return ignoreCertificateErrors;
+        }
+
+        public boolean isUpdateCommitStatus() {
+            return updateCommitStatus;
         }
 
         public Map<Integer, GitlabMergeRequestWrapper> getMergeRequests(String projectName) {

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
@@ -83,6 +83,10 @@ public class GitlabBuilds {
         sb.append("[").append(url).append("](").append(url).append(")");
         repository.createNote(cause.getMergeRequestId(), sb.toString(), false, false);
 
+        if (trigger.getDescriptor().isUpdateCommitStatus()) {
+            repository.createCommitStatus(cause.getMergeRequestId(), "running", url);
+        }
+
     }
 
     public void onCompleted(AbstractBuild build) {
@@ -134,6 +138,10 @@ public class GitlabBuilds {
         }
 
         repository.createNote(cause.getMergeRequestId(), stringBuilder.toString(), shouldClose, shouldMerge);
+
+        if (trigger.getDescriptor().isUpdateCommitStatus()) {
+            repository.createCommitStatus(cause.getMergeRequestId(), (build.getResult() == Result.SUCCESS) ? "success" : "failure", buildUrl);
+        }
     }
 
     private String getOnStartedMessage(GitlabCause cause) {

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.gitlab;
 import org.apache.commons.lang.StringUtils;
 import org.gitlab.api.GitlabAPI;
 import org.gitlab.api.models.GitlabCommit;
+import org.gitlab.api.models.GitlabCommitStatus;
 import org.gitlab.api.models.GitlabMergeRequest;
 import org.gitlab.api.models.GitlabNote;
 import org.gitlab.api.models.GitlabProject;
@@ -347,6 +348,22 @@ public class GitlabMergeRequestWrapper {
             return null;
         }
 
+    }
+
+    public GitlabCommitStatus createCommitStatus(String status, String targetUrl) {
+        try {
+            GitlabAPI api = builder.getGitlab().get();
+            GitlabMergeRequest mergeRequest = api.getMergeRequest(project, id);
+            GitlabCommit latestCommit = getLatestCommit(mergeRequest, api);
+
+            if (latestCommit != null) {
+                return api.createCommitStatus(project, latestCommit.getId(), status, mergeRequest.getSourceBranch(), "Jenkins", targetUrl, null);
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "Failed to set commit status for merge request " + id, e);
+        }
+
+        return null;
     }
 
     private void build(Map<String, String> customParameters) {

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabRepository.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.gitlab;
 
+import org.gitlab.api.models.GitlabCommitStatus;
 import org.gitlab.api.models.GitlabMergeRequest;
 import org.gitlab.api.models.GitlabNote;
 import org.gitlab.api.models.GitlabProject;
@@ -123,5 +124,10 @@ public class GitlabRepository {
     public GitlabNote createNote(Integer mergeRequestId, String message, boolean shouldClose, boolean shouldMerge) {
         GitlabMergeRequestWrapper gitlabMergeRequestWrapper = mergeRequests.get(mergeRequestId);
         return gitlabMergeRequestWrapper.createNote(message, shouldClose, shouldMerge);
+    }
+
+    public GitlabCommitStatus createCommitStatus(Integer mergeRequestId, String status, String targetUrl) {
+        GitlabMergeRequestWrapper gitlabMergeRequestWrapper = mergeRequests.get(mergeRequestId);
+        return gitlabMergeRequestWrapper.createCommitStatus(status, targetUrl);
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/global.jelly
@@ -34,5 +34,9 @@
     <f:entry title="${%Ignore SSL Certificate Errors}" field="ignoreCertificateErrors">
       <f:checkbox />
     </f:entry>
+    <f:entry title="${%Update commit status}" field="updateCommitStatus"
+        description="Gitlab 8.1 required">
+      <f:checkbox />
+    </f:entry>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
Gitlab 8.1 will include a Commit Status API which will allow external programs (like Jenkins) to update the status of commits in Gitlab, similar to how Gitlab CI does. This PR ensures this runner updates Gitlab using the new API.

This functionality relies on the changes made in timols/java-gitlab-api#77 to the underlying Java Gitlab library.

This functionality can be enabled in the global plugins settings as it's only available on Gitlab 8.1. If it was enabled though it would similarly fail when making the requests and log an error.

Current this looks like this (the green tick by the commit hash):

![Example](https://www.dropbox.com/s/ttemfzrrao1qoxf/Screenshot%202015-10-16%2012.01.08.png?dl=1)

However a [feature request has been made](https://gitlab.com/gitlab-org/gitlab-ce/issues/3082) which could change the status of the _Merge_ button, like Github pull requests, which could mean we could disable the comments and use commit status exclusively.