### PR TITLE
Fixed trigger commit logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
@@ -41,36 +43,42 @@
         </repository>
     </repositories>
 
-  <dependencies>
-      <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-all</artifactId>
-          <version>1.3</version>
-          <scope>test</scope>
-      </dependency>
-
-      <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <version>4.11</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>commons-httpclient</groupId>
-          <artifactId>commons-httpclient</artifactId>
-          <version>3.1</version>
-      </dependency>
-      <dependency>
-          <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-mapper-asl</artifactId>
-          <version>1.9.9</version>
-      </dependency>
-      <dependency>
-          <groupId>org.gitlab</groupId>
-          <artifactId>java-gitlab-api</artifactId>
-          <version>1.1.4</version>
-      </dependency>
-  </dependencies>
+    <dependencies>
+        <!-- JMockit's dependency must be declared before that of JUnit. -->
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>1.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+            <version>3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gitlab</groupId>
+            <artifactId>java-gitlab-api</artifactId>
+            <version>1.1.4</version>
+        </dependency>
+    </dependencies>
 
   <pluginRepositories>
       <pluginRepository>

--- a/src/test/java/com/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper_check_Test.java
+++ b/src/test/java/com/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper_check_Test.java
@@ -1,0 +1,174 @@
+package com.jenkinsci.plugins.gitlab;
+
+import hudson.util.Secret;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.NonStrictExpectations;
+import mockit.Tested;
+import mockit.Verifications;
+import mockit.integration.junit4.JMockit;
+import org.gitlab.api.GitlabAPI;
+import org.gitlab.api.models.GitlabCommit;
+import org.gitlab.api.models.GitlabMergeRequest;
+import org.gitlab.api.models.GitlabNote;
+import org.gitlab.api.models.GitlabProject;
+import org.gitlab.api.models.GitlabUser;
+import org.jenkinsci.plugins.gitlab.GitlabBuildTrigger;
+import org.jenkinsci.plugins.gitlab.GitlabMergeRequestBuilder;
+import org.jenkinsci.plugins.gitlab.GitlabMergeRequestStatus;
+import org.jenkinsci.plugins.gitlab.GitlabMergeRequestWrapper;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static mockit.Deencapsulation.getField;
+import static mockit.Deencapsulation.invoke;
+import static mockit.Deencapsulation.setField;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JMockit.class)
+public class GitlabMergeRequestWrapper_check_Test {
+    @Injectable GitlabAPI api;
+    @Injectable GitlabBuildTrigger trigger;
+    @Injectable GitlabMergeRequest mergeRequest;
+    @Injectable GitlabMergeRequestBuilder builder;
+    @Injectable GitlabProject project;
+    @Tested GitlabMergeRequestWrapper subject;
+    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-DD");
+    GitlabCommit commit = new GitlabCommit();
+    GitlabNote jenkinsNote = new GitlabNote();
+    GitlabNote triggerNote = new GitlabNote();
+    GitlabUser botUser = new GitlabUser();
+
+    // Mock dependencies used during static initialization.
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        new MockUp<GitlabBuildTrigger.GitlabBuildTriggerDescriptor>() {
+            @Mock void load() {}
+        };
+
+        new MockUp<Secret>() {
+            @Mock Secret fromString(String data) { return null; }
+        };
+    }
+
+    @Before
+    public void before() throws Exception {
+        new MockUp<GitlabBuildTrigger.GitlabBuildTriggerDescriptor>() {
+            @Mock String getBotUsername() { return "test-bot-username"; }
+        };
+
+        new NonStrictExpectations() {{
+            api.getCommits(mergeRequest); result = Arrays.asList(commit);
+            trigger.getAssigneeFilter(); result = "";
+            trigger.getTriggerComment(); result = "test-trigger-comment";
+        }};
+
+        botUser.setUsername("test-bot-username");
+        commit.setId("test-commit-id");
+        jenkinsNote.setAuthor(botUser);
+        jenkinsNote.setBody("test-jenkins-note");
+        jenkinsNote.setCreatedAt(dateFormat.parse("2015-01-01"));
+        triggerNote.setBody("test-trigger-comment");
+        triggerNote.setCreatedAt(dateFormat.parse("2015-01-02"));
+    }
+
+    // This test asserts the default givens for this suite. Individual test methods will identify when they change this.
+    @Test
+    public void given_noJenkinsNote_noLastNote_latestCommitIsNotReached() throws Exception {
+        assertNull(invoke(subject, "getJenkinsNote", mergeRequest, api));
+        assertNull(invoke(subject, "getLastNote", mergeRequest, api));
+        assertTrue((boolean) invoke(subject, "latestCommitIsNotReached", commit));
+    }
+
+    @Test
+    public void builds() throws Exception {
+        subject.check(mergeRequest);
+
+        new Verifications() {{
+            invoke(subject, "build", new HashMap<String, String>());
+        }};
+    }
+
+    @Test
+    public void builds_givenAJenkinsNote() throws Exception {
+        new Expectations() {{
+            api.getAllNotes(mergeRequest); result = Arrays.asList(jenkinsNote);
+        }};
+
+        assertEquals(invoke(subject, "getJenkinsNote", mergeRequest, api), jenkinsNote);
+
+        subject.check(mergeRequest);
+
+        new Verifications() {{
+            invoke(subject, "build", new HashMap<String, String>());
+        }};
+    }
+
+    @Test
+    public void doesNotBuild_givenAJenkinsNoteAndAReachableLatestCommit() throws Exception {
+        new MockUp<GitlabMergeRequestWrapper>() {
+            @Mock(invocations = 0) void build(Map m) {}
+        };
+
+        new Expectations() {{
+            api.getAllNotes(mergeRequest); result = Arrays.asList(jenkinsNote);
+        }};
+
+        ((GitlabMergeRequestStatus) getField(subject, "mergeRequestStatus")).setLatestCommitOfMergeRequest(
+                mergeRequest.getId().toString(),
+                commit.getId());
+
+        assertEquals(invoke(subject, "getJenkinsNote", mergeRequest, api), jenkinsNote);
+        assertFalse((boolean) invoke(subject, "latestCommitIsNotReached", commit));
+
+        subject.check(mergeRequest);
+    }
+
+    @Test
+    public void doesNotBuild_givenAReachableLatestCommit() throws Exception {
+        new MockUp<GitlabMergeRequestWrapper>() {
+            @Mock(invocations = 0) void build(Map m) {}
+        };
+
+        setAReachableLatestCommit();
+
+        subject.check(mergeRequest);
+    }
+
+    @Test
+    public void builds_givenATriggerCommentAndAReachableLatestCommit() throws Exception {
+        new Expectations() {{
+            api.getAllNotes(mergeRequest); result = Arrays.asList(triggerNote);
+        }};
+
+        setAReachableLatestCommit();
+
+        assertEquals(invoke(subject, "getLastNote", mergeRequest, api), triggerNote);
+        assertFalse((boolean) invoke(subject, "latestCommitIsNotReached", commit));
+
+        subject.check(mergeRequest);
+
+        new Verifications() {{
+            invoke(subject, "build", new HashMap<String, String>());
+        }};
+    }
+
+    private void setAReachableLatestCommit() {
+        ((GitlabMergeRequestStatus) getField(subject, "mergeRequestStatus")).setLatestCommitOfMergeRequest(
+                mergeRequest.getId().toString(),
+                commit.getId());
+    }
+}


### PR DESCRIPTION
Gitlab Merge Request Builder 1.2.3 introduced a logic bug whereby merge requests already processed by the plugin whose Jenkins user comments had been deleted would not trigger another build, even when a trigger comment was added. (Deleting all Jenkins user comments from a MR used to be a workaround to retrigger a build before the trigger comment feature was introduced - thanks @vbyjsue!)

This bug is demonstrated by the failing builds_givenATriggerCommentAndAReachableLatestCommit on commit 448cc48. Additional GitlabMergeRequestWrapper.check() tests were implemented in order to help ensure that the next commit's bug fix wouldn't break other things.