### PR TITLE
Fixing NPE in assigneeFilterMatch

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
@@ -165,7 +165,7 @@ public class GitlabMergeRequestWrapper {
         if (assigneeFilter.equals("")) {
             shouldRun = true;
         } else {
-            if (assignee.equals(assigneeFilter)) {
+            if (assigneeFilter.equals(assignee)) {
                 shouldRun = true;
             } else {
                 shouldRun = false;


### PR DESCRIPTION
- Closes #151

There are probably more elegant ways of doing this but I'm being defensive and leveraging the fact that assigneeFilter.equals is called on line 165 so it should be safe to call it again.