### PR TITLE
Corrected value to use in Branch Specifier for forked repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ request indicating whether the merge request was successful.
 * In the ``Source Code Management`` section:
     * Click ``Git`` and enter your Repository URL and in Advanced set its Name to ``origin``
     * For merge requests from forked repositories add another repository with Repository URL ``${gitlabSourceRepository}`` and in Advanced set Name to ``${gitlabSourceName}``
-    * In ``Branch Specifier`` enter ``refs/remotes/origin/${gitlabSourceBranch}`` or for merge requests from forked repositories enter ``refs/remotes/${gitlabSourceName}/${gitlabSourceBranch}``
+    * In ``Branch Specifier`` enter ``refs/remotes/origin/${gitlabSourceBranch}`` or for merge requests from forked repositories enter ``${gitlabSourceName}/${gitlabSourceBranch}``
     * In the ``Additional Behaviours`` section:
         * Click the ``Add`` drop down button and the ``Merge before build`` item
         * Specify the name of the repository as ``origin`` (if origin corresponds to Gitlab) and enter the


### PR DESCRIPTION
This pull request is a tiny tweak to the README regarding the Branch Specifier setting for forked repos. I was tripped up by this until I saw the discussion in issue #144.