### PR TITLE
Add option to control relay of gitlab parameters to build command

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
@@ -34,4 +34,8 @@
             description="On success, auto merge the request">
         <f:checkbox />
     </f:entry>
+    <f:entry title="Relay Gitlab parameters to build command" field="relayGitlabParametersToBuild"
+            description="If checked, all gitlab-prefixed parameters (gitlabSourceBranch, gitlabTargetBranch, gitlabDescription, etc) will be passed to the build command as -D options (environment variables). Consider this option on Windows systems, where multi-line commit comments in gitlabDescription may prevent successful builds.">
+        <f:checkbox />
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
This pull request may be incomplete, particularly in the area of tests, but I'm hoping it will spark a discussion regarding a problem we are encountering.

Our team currently has Jenkins deployed on Windows and is using this plugin with a project that has a Gradle build.

The following console log from a merge request triggered build demonstrates the problem:

```
[Gradle] - Launching build.
[project-master-pull-requests] $ cmd.exe /C '"E:\Jenkins\tools\hudson.plugins.gradle.GradleInstallation\Gradle_2.9\bin\gradle.bat -DgitlabMergeRequestIid=1 -DgitlabSourceName=someone/project -DgitlabSourceRepository=https://somewhere.edu/someone/project.git -DgitlabMergeRequestId=125 -DgitlabSourceBranch=isolate-integration-tests -DgitlabTargetBranch=master "-DgitlabDescription=Gradle doesn't have a facility for automatically excluding integration tests (by naming or such).
Also:

* ITests move to a new package. Moving the rest to the same package will occur in a later contribution.
* Modifies .gitignore for Eclipse developers
* Updates README to include build instructions." clean build && exit %%ERRORLEVEL%%"'
:help

Welcome to Gradle 2.9.

To run a build, run gradle <task> ...

To see a list of available tasks, run gradle tasks

To see a list of command-line options, run gradle --help

To see more detail about a task, run gradle help --task <task>

BUILD SUCCESSFUL

Total time: 3.094 secs
Build step 'Invoke Gradle script' changed build result to SUCCESS
Finished: SUCCESS
```

The source branch has a single, multi-line commit. That full commit message is passed by gitlabs into `gitlabDescription`. The presence of the newlines in the commit trips up an issue with Jenkins on Windows (see https://issues.jenkins-ci.org/browse/JENKINS-20505 I think), resulting in the command line being formatted incorrectly.

Our thought is: we don't need the Gradle build to see any of these gitlab-prefixed parameters. This pull request makes a new option, "Relay Gitlab parameters to build command", that is true by default for backwards compatibility. If false however, that should address the issue with our build.

Thoughts?