### PR TITLE
do not send an empty trigger message even if we should not run a build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
@@ -76,7 +76,7 @@ public class GitlabBuilds {
 	        return withCustomParameters(new StringBuilder("Build triggered."), customParameters).toString();
     	} else {
     		LOGGER.info("Build is not supposed to run");
-    		return "";
+    		return "Build triggered. But it is not supposed to run.";
     	}
     }
     


### PR DESCRIPTION
when option `Enable build triggered message` is checked, we periodically leave a comment, like `Build triggered` or so,  for a MR, if the build is not supposed to run, e.g. we have built it previously and there is no new commit get pushed, then we send a empty trigger message to gitlab, this empty thing will hit an exception like this:
```
    org.gitlab.api.GitlabAPIException: {"message":"400 (Bad request) \"body\" not given"}
        at org.gitlab.api.http.GitlabHTTPRequestor.handleAPIError(GitlabHTTPRequestor.java:369)
        at org.gitlab.api.http.GitlabHTTPRequestor.to(GitlabHTTPRequestor.java:146)
        at org.gitlab.api.http.GitlabHTTPRequestor.to(GitlabHTTPRequestor.java:116)
        at org.gitlab.api.GitlabAPI.createNote(GitlabAPI.java:1073)
        at org.jenkinsci.plugins.gitlab.GitlabMergeRequestWrapper.createNote(GitlabMergeRequestWrapper.java:217)
        at org.jenkinsci.plugins.gitlab.GitlabMergeRequestWrapper.build(GitlabMergeRequestWrapper.java:258)
        ...
```

Signed-off-by: runsisi <runsisi@hust.edu.cn>