### PR TITLE
fix null pointer access in GitlabBuilds::build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabBuilds.java
@@ -54,7 +54,8 @@ public class GitlabBuilds {
     		String assigneeFilter = trigger.getAssigneeFilter();
     		
     		if (!"".equals(assigneeFilter)) {
-    			shouldRun = filterMatch(assigneeFilter, mergeRequest.getAssignee().getUsername(), "Assignee");
+    			String assigneeName = mergeRequest.getAssignee() != null ? mergeRequest.getAssignee().getUsername() : null;
+    			shouldRun = filterMatch(assigneeFilter, assigneeName, "Assignee");
     		}
         }
     	


### PR DESCRIPTION
assignee is not a mandatory field for a merge request, we need to test it before accessing its members, or we will hit an exception like this:

    org.jenkinsci.plugins.gitlab.GitlabBuildTrigger.run() failed for hudson.model.FreeStyleProject@3a9ce644[test]
    java.lang.NullPointerException
        at org.jenkinsci.plugins.gitlab.GitlabBuilds.build(GitlabBuilds.java:57)
        at org.jenkinsci.plugins.gitlab.GitlabMergeRequestWrapper.build(GitlabMergeRequestWrapper.java:255)
        at org.jenkinsci.plugins.gitlab.GitlabMergeRequestWrapper.check(GitlabMergeRequestWrapper.java:100)
        at org.jenkinsci.plugins.gitlab.GitlabRepository.check(GitlabRepository.java:86)
        at org.jenkinsci.plugins.gitlab.GitlabRepository.check(GitlabRepository.java:68)
        at org.jenkinsci.plugins.gitlab.GitlabMergeRequestBuilder.run(GitlabMergeRequestBuilder.java:28)
        at org.jenkinsci.plugins.gitlab.GitlabBuildTrigger.run(GitlabBuildTrigger.java:134)
        at hudson.triggers.Trigger.checkTriggers(Trigger.java:272)
        at hudson.triggers.Trigger$Cron.doRun(Trigger.java:221)

Signed-off-by: runsisi <runsisi@hust.edu.cn>