### PR TITLE
Correct helper text for 'Target Branch Regex' field

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
@@ -5,7 +5,7 @@
         <f:textbox />
     </f:entry>
     <f:entry title="Target Branch Regex" field="targetBranchRegex"
-            description="The full path including namespace to the project">
+            description="Trigger build only if the target branch of the merge request matches this regex.">
         <f:textbox />
     </f:entry>
     <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">


### PR DESCRIPTION
The text was wrongly copy-pasted from the previous field, 'Gitlab Project Path' and related to that field.