### PR TITLE
fix null pointer access in GitlabMergeRequestWrapper::check

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabMergeRequestWrapper.java
@@ -95,6 +95,10 @@ public class GitlabMergeRequestWrapper {
         try {
             GitlabAPI api = builder.getGitlab().get();
             GitlabCommit latestCommit = getLatestCommit(gitlabMergeRequest, api);
+
+            if (latestCommit == null) { // the source branch has been removed
+                return;
+            }
             
             Map<String, String> customParameters = getSpecifiedCustomParameters(gitlabMergeRequest, api);
             build(customParameters, latestCommit.getId(), gitlabMergeRequest);


### PR DESCRIPTION
if the source branch of the MR has been removed then `getLatestCommit` will
return null, we should not try to build it

Signed-off-by: runsisi <runsisi@hust.edu.cn>