### PR TITLE
Contribute environment variables to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ work/*
 .gradle
 build/
 classes/
+.factorypath

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ These include:
 __Note:__  a manually triggered build will not add build triggered/succeeded/failed comments to the merge request.
 __Note:__  You should ensure that the 'Global Config user.name Value' and 'Global Config user.email Value' are both set for your git plugin.  In some cases, you will get an error indicating that a branch cannot be merged if these are not set.
 
+## Environment variables
+
+The plugin will contribute some environment variables to the build.
+
+* **gitlabMergeRequestId**
+* **gitlabMergeRequestIid**
+* **gitlabSourceName**
+* **gitlabSourceRepository**
+* **gitlabSourceBranch**
+* **gitlabTargetBranch**
+* **gitlabTitle**
+* **gitlabDescription**
+* **gitlabSourceProjectId**
+* **gitlabTargetProjectId**
+* **gitlabLastCommitId**
+
 ## Contributing
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitLabEnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitLabEnvironmentContributor.java
@@ -1,0 +1,37 @@
+package org.jenkinsci.plugins.gitlab;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+@Extension
+public class GitLabEnvironmentContributor extends EnvironmentContributor {
+    @Override
+    public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs,
+        @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        GitlabCause cause = (GitlabCause) r.getCause(GitlabCause.class);
+        if (cause != null) {
+            Map<String, String> variables = new HashMap<>();
+            variables.put("gitlabMergeRequestId", cause.getMergeRequestId() + "");
+            variables.put("gitlabMergeRequestIid", cause.getMergeRequestIid() + "");
+            variables.put("gitlabSourceName", cause.getSourceName());
+            variables.put("gitlabSourceRepository", cause.getSourceRepository());
+            variables.put("gitlabSourceBranch", cause.getSourceBranch());
+            variables.put("gitlabTargetBranch", cause.getTargetBranch());
+            variables.put("gitlabTitle", cause.getTitle());
+            variables.put("gitlabDescription", cause.getDescription());
+            variables.put("gitlabSourceProjectId", cause.getSourceProjectId()+"");
+            variables.put("gitlabTargetProjectId", cause.getTargetProjectId()+"");
+            variables.put("gitlabLastCommitId", cause.getLastCommitId());
+            envs.overrideAll(variables);
+        }
+    }
+}


### PR DESCRIPTION
I need these variables in order to report static code analysis back to GitLab.

Using:
https://github.com/tomasbjerre/violation-comments-to-gitlab-plugin

Result wIll look like:

https://gitlab.com/tomas.bjerre85/violations-test/merge_requests/1

Config looks like:

![screencapture-localhost-8080-job-mr-configure-1487703273361](https://cloud.githubusercontent.com/assets/439571/23179854/a2fcb32a-f86f-11e6-9117-db3bb9349651.png)
