### PR TITLE
set java.level for enforcer and fixed findbugs error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <!-- which version of Jenkins is this plugin built against? -->
+        <java.level>8</java.level>
         <jenkins.version>2.121</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.compiler.version>1.8</java.compiler.version>

--- a/src/main/java/org/jenkinsci/plugins/gitlab/GitlabWebhooks.java
+++ b/src/main/java/org/jenkinsci/plugins/gitlab/GitlabWebhooks.java
@@ -44,8 +44,8 @@ public class GitlabWebhooks implements UnprotectedRootAction {
      * @return
      */
     private static GitlabBuildTrigger findTrigger(MergeRequest m) {
-        for (String key : triggers.keySet()) {
-            GitlabBuildTrigger t = triggers.get(key);
+        for (Map.Entry<String, GitlabBuildTrigger> entry : triggers.entrySet()) {
+            GitlabBuildTrigger t = entry.getValue();
             try {
                 if (t.getProjectPath().equals(m.getTarget().path_with_namespace)) {
                     return t;


### PR DESCRIPTION
set java.level to 8 for jenkins parent pom, resolving:-

[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (display-info) @ gitlab-merge-request-jenkins ---
[INFO] Restricted to JDK 1.7 yet org.kohsuke.stapler:stapler-jelly:jar:1.254:provided contains org/kohsuke/stapler/jelly/JellyViewScript.class targeted to JDK 1.8
[INFO] Restricted to JDK 1.7 yet org.kohsuke.stapler:stapler-jrebel:jar:1.254:provided contains org/kohsuke/stapler/JRebelFacet$ReloaderHook$1.class targeted to JDK 1.8
[INFO] Restricted to JDK 1.7 yet org.kohsuke.stapler:stapler:jar:1.254:provided contains org/kohsuke/stapler/CrumbIssuer.class targeted to JDK 1.8
[INFO] Restricted to JDK 1.7 yet org.jenkins-ci:task-reactor:jar:1.5:provided contains org/jvnet/hudson/reactor/Reactor$1.class targeted to JDK 1.8
[INFO] Restricted to JDK 1.7 yet org.kohsuke.stapler:stapler-groovy:jar:1.254:provided contains org/kohsuke/stapler/jelly/groovy/Namespace.class targeted to JDK 1.8
[INFO] Restricted to JDK 1.7 yet org.jenkins-ci.main:remoting:jar:3.20:provided contains hudson/remoting/AbstractByteArrayCommandTransport$1.class targeted to JDK 1.8

and resolved:

org.jenkinsci.plugins.gitlab.GitlabWebhooks.findTrigger(MergeRequest) makes inefficient use of keySet iterator instead of entrySet iterator [org.jenkinsci.plugins.gitlab.GitlabWebhooks] At GitlabWebhooks.java:[line 48] WMI_WRONG_MAP_ITERATOR