### PR TITLE
[JENKINS-74088] [JENKINS-74089] Migrate legacy checkUrl attribute in `GitlabBuildTrigger/global.jelly & config.jelly`

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/config.jelly
@@ -9,7 +9,7 @@
         <f:textbox />
     </f:entry>
     <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
-        <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
+        <f:textbox default="${descriptor.cron}" checkUrl="descriptorByName/hudson.triggers.TimerTrigger/checkSpec" checkDependsOn=""/>
     </f:entry>
     <f:entry title="Assignee filter" field="assigneeFilter"
             description="Trigger build only if merge request is assigned to assignee username. No value will always trigger job, regardless of assignee.">

--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/global.jelly
@@ -14,7 +14,7 @@
       <f:password/>
     </f:entry>
     <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
-      <f:textbox default="H/5 * * * *" />
+      <f:textbox default="H/5 * * * *" checkUrl="descriptorByName/hudson.triggers.TimerTrigger/checkSpec" checkDependsOn=""/>
     </f:entry>
     <f:entry title="Assignee Filter" field="assigneeFilter"
         description="Trigger build only if merge request is assigned to assignee username. No value will always trigger job, regardless of assignee.">

--- a/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlab/GitlabBuildTrigger/global.jelly
@@ -14,7 +14,7 @@
       <f:password/>
     </f:entry>
     <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
-      <f:textbox default="H/5 * * * *" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
+      <f:textbox default="H/5 * * * *" />
     </f:entry>
     <f:entry title="Assignee Filter" field="assigneeFilter"
         description="Trigger build only if merge request is assigned to assignee username. No value will always trigger job, regardless of assignee.">


### PR DESCRIPTION
**Requires #234**

[JENKINS-74088](https://issues.jenkins.io/browse/JENKINS-74088)
[JENKINS-74089](https://issues.jenkins.io/browse/JENKINS-74089)

**Why**
https://www.jenkins.io/doc/developer/security/csp/#legacy-javascript-checkurl-validation

Removes the legacy checkURL attributes

**Testing done**

Before Changes:
https://github.com/user-attachments/assets/8455beae-09a1-412e-8f6a-2ead75a9c9f6

After Changes:
https://github.com/user-attachments/assets/64e33d3b-ed9d-46be-b31b-d905972c2489

